### PR TITLE
Fix index parsing in selection loop

### DIFF
--- a/scripts/m365-module-install-menu.ps1
+++ b/scripts/m365-module-install-menu.ps1
@@ -118,8 +118,9 @@ else {
     # Process as a comma-separated list of numbers
     $selections = $inputChoice -split ",\s*"
     foreach ($sel in $selections) {
-        if ([int]::TryParse($sel, [ref]$null)) {
-            $index = [int]$sel - 1
+        $parsedIndex = 0
+        if ([int]::TryParse($sel, [ref]$parsedIndex)) {
+            $index = $parsedIndex - 1
             if ($index -ge 0 -and $index -lt $modules.Count) {
                 $modName = $modules[$index].Name
                 Install-ModuleWithUpdateCheck -moduleName $modName


### PR DESCRIPTION
## Summary
- handle integer parsing correctly in the module selection loop

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_682bd188b84c83249b4bb9afa9427cf4